### PR TITLE
Remove unused assembly attributes

### DIFF
--- a/src/CalculatedCharacteristics/Properties/AssemblyInfo.cs
+++ b/src/CalculatedCharacteristics/Properties/AssemblyInfo.cs
@@ -1,13 +1,9 @@
 ﻿#region usings
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 #endregion
 
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
-
-// In order to mock internal interfaces Moq requires the following attribute because it is strong-named.
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/CalculatedCharacteristics/Properties/AssemblyInfo.cs
+++ b/src/CalculatedCharacteristics/Properties/AssemblyInfo.cs
@@ -11,4 +11,3 @@ using System.Runtime.InteropServices;
 
 // In order to mock internal interfaces Moq requires the following attribute because it is strong-named.
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-[assembly: InternalsVisibleTo("Shared.CalculatedCharacteristics.Tests")]


### PR DESCRIPTION
Remove the "InteralsVisibleToAttribute" for legacy namespace. Also Mock does not require access to internals too.