### PR TITLE
Update project to PiWeb-API 8.0.0 alpha0074

### DIFF
--- a/src/CalculatedCharacteristics.Tests/ValueCalculatorTest.cs
+++ b/src/CalculatedCharacteristics.Tests/ValueCalculatorTest.cs
@@ -27,9 +27,10 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 	{
 		#region members
 
-		private static readonly CharacteristicCalculatorFactory EmptyCharacteristicCalculatorFactory = ( _ => null );
-		private static readonly ChildPathsHandler EmptyChildPathsHandler = ( _ => Enumerable.Empty<PathInformationDto>() );
-		private static readonly EntityAttributeValueHandler EmptyEntityAttributeValueHandler = ( ( _, _, _ ) => null );
+		private static readonly CharacteristicCalculatorFactory EmptyCharacteristicCalculatorFactory = _ => null;
+		private static readonly ChildPathsHandler EmptyChildPathsHandler = _ => Enumerable.Empty<PathInformationDto>();
+		private static readonly EntityAttributeValueHandler EmptyEntityAttributeValueHandler = ( _, _, _ ) => null;
+		private static readonly ValueCalculator.MeasurementValueHandler EmptyMeasurementValueHandler = ( _, _ ) => null;
 
 		#endregion
 
@@ -42,7 +43,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 			const string formula = null;
 
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When/Then
 			Assert.That( () => valueCalculator.Parse( formula!, null ), Throws.ArgumentNullException );
@@ -55,7 +56,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 			const string formula = "";
 
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When/Then
 			Assert.That( () => valueCalculator.Parse( formula, null ), Throws.TypeOf<ParserException>() );
@@ -68,7 +69,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 			const string formula = "1{{/";
 
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When/Then
 			Assert.That( () => valueCalculator.Parse( formula, null ), Throws.TypeOf<ParserException>() );
@@ -81,7 +82,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 			const string formula = "1 + 1";
 
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When
 			var mathCalculator = valueCalculator.Parse( formula, null );
@@ -99,7 +100,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
 			var mathCalculator = mathInterpreter.Parse( formula, null );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When
 			var result1 = valueCalculator.CalculateValue( null, new DataMeasurementDto(), mathCalculator );
@@ -123,7 +124,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 			var mathCalculator = mathInterpreter.Parse( formula, null );
 			var valueCalculator = new ValueCalculator(
 				mathInterpreter,
-				GetMeasurementValue,
+				EmptyMeasurementValueHandler,
 				EmptyEntityAttributeValueHandler,
 				( _, _ ) => false ); // delegate checking whether the characteristic 'ch' belongs to the part with the given 'uuid'
 
@@ -176,7 +177,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 		{
 			//Given
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When/Then
 			Assert.That( () => valueCalculator.CalculateValuesForCalculatedCharacteristics( null!, Array.Empty<DataMeasurementDto>(), false ),
@@ -195,7 +196,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 			var emptyCharacteristics = Array.Empty<InspectionPlanDtoBase>();
 
 			var mathInterpreter = new MathInterpreter( EmptyCharacteristicCalculatorFactory, EmptyChildPathsHandler );
-			var valueCalculator = new ValueCalculator( mathInterpreter, GetMeasurementValue, EmptyEntityAttributeValueHandler );
+			var valueCalculator = new ValueCalculator( mathInterpreter, EmptyMeasurementValueHandler, EmptyEntityAttributeValueHandler );
 
 			//When
 			var calculationResult1 = valueCalculator.CalculateValuesForCalculatedCharacteristics( emptyCharacteristics, measurements, false );

--- a/src/CalculatedCharacteristics/CalculatedCharacteristics.csproj
+++ b/src/CalculatedCharacteristics/CalculatedCharacteristics.csproj
@@ -6,12 +6,12 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>Zeiss.PiWeb.CalculatedCharacteristics</RootNamespace>
     <LangVersion>latest</LangVersion>
-    <PackageVersion>2.0.0-alpha0003</PackageVersion>
+    <PackageVersion>3.0.0-alpha0001</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly information">
     <AssemblyName>Zeiss.PiWeb.CalculatedCharacteristics</AssemblyName>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
     <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
     <Copyright>Copyright © 2021 $(Company)</Copyright>
     <FileVersion>$(AssemblyVersion)</FileVersion>
@@ -26,7 +26,7 @@
       The package defines the business logic to parse and evaluate formulas of calculated characteristics in PiWeb applications.
     </Description>
     <PackageId>Zeiss.PiWeb.CalculatedCharacteristics</PackageId>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <PackageIcon>logo_128x128.png</PackageIcon>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/ZEISS-PiWeb/PiWeb-Calculated-Characteristics</PackageProjectUrl>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PiWebApiVersion>8.0.0-alpha0008</PiWebApiVersion>
+    <PiWebApiVersion>8.0.0-alpha0074</PiWebApiVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CalculatedCharacteristics/Delegates.cs
+++ b/src/CalculatedCharacteristics/Delegates.cs
@@ -18,7 +18,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 	/// <summary>
 	/// Delegate used to get the value for an entity.
 	/// </summary>
-	public delegate double? MeasurementValueHandler( [NotNull] PathInformationDto path );
+	public delegate double? MeasurementValueHandler( [NotNull] PathInformationDto characteristicPath );
 
 	/// <summary>
 	/// Delegate to get the value for a characteristic.

--- a/src/CalculatedCharacteristics/ValueCalculator.cs
+++ b/src/CalculatedCharacteristics/ValueCalculator.cs
@@ -111,7 +111,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 		/// <param name="calculator">The <see cref="IMathCalculator"/> to calculate the value.</param>
 		/// <returns>The calculated value.</returns>
 		[CanBeNull]
-		public DataCharacteristicDto CalculateValue(
+		public DataValueDto? CalculateValue(
 			[CanBeNull] InspectionPlanDtoBase characteristic,
 			[CanBeNull] DataMeasurementDto measurement,
 			[CanBeNull] IMathCalculator calculator )
@@ -128,10 +128,11 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 				_EntityAttributeValueHandler,
 				measurement.Time );
 
-			var existingDataCharacteristic = measurement.Characteristics.SingleOrDefault( dc => dc.Uuid == characteristic.Uuid );
-			var newDataCharacteristic = CreateDataCharacteristicForCalculatedValue( calculatedValue, characteristic, existingDataCharacteristic );
+			var existingDataValue = measurement.Characteristics.TryGetValue( characteristic.Uuid, out var value )
+				? value
+				: (DataValueDto?)null;
 
-			return newDataCharacteristic;
+			return CreateDataValueForCalculatedValue( calculatedValue, existingDataValue );
 		}
 
 		/// <summary>
@@ -169,8 +170,8 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 
 					foreach( var measurement in measurements )
 					{
-						var newDataCharacteristic = CalculateValue( characteristic, measurement, calculator );
-						result.SetUpdatedCharacteristic( measurement.Uuid, characteristic.Uuid, newDataCharacteristic );
+						var newDataValue = CalculateValue( characteristic, measurement, calculator );
+						result.SetUpdatedCharacteristic( measurement.Uuid, characteristic.Uuid, newDataValue );
 					}
 				}
 				catch( Exception ex )
@@ -186,10 +187,13 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 					// Remove already existing value for the calculated characteristic
 					foreach( var measurement in measurements )
 					{
+						var existingDataValue = measurement.Characteristics.TryGetValue( characteristic.Uuid, out var value )
+							? value
+							: (DataValueDto?)null;
+
 						// Remove the measured value only and keep the DataCharacteristic if it still contains other attribute values
-						var existingDataCharacteristic = measurement.Characteristics.FirstOrDefault( dc => dc.Uuid == characteristic.Uuid );
-						var newDataCharacteristic = CreateDataCharacteristicForCalculatedValue( null, characteristic, existingDataCharacteristic );
-						result.SetUpdatedCharacteristic( measurement.Uuid, characteristic.Uuid, newDataCharacteristic );
+						var newDataValue = CreateDataValueForCalculatedValue( null, existingDataValue );
+						result.SetUpdatedCharacteristic( measurement.Uuid, characteristic.Uuid, newDataValue );
 					}
 				}
 			}
@@ -198,18 +202,15 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 		}
 
 		/// <summary>
-		/// Creates a DataCharacteristic for the calculated value of the given characteristic.
-		/// If an <paramref name="existingDataCharacteristic"/> is available for the characteristic,
-		/// its attribute values (besides the measured value) are copied into the new DataCharacteristic.
+		/// Creates a DataValueDto for the calculated value of the given characteristic.
+		/// If an <paramref name="existingDataValue"/> is available for the characteristic,
+		/// its attribute values (besides the measured value) are copied into the new DataValueDto.
 		/// </summary>
 		[CanBeNull]
-		private static DataCharacteristicDto CreateDataCharacteristicForCalculatedValue(
-			double? calculatedValue,
-			[NotNull] InspectionPlanDtoBase characteristic,
-			[CanBeNull] DataCharacteristicDto existingDataCharacteristic )
+		private static DataValueDto? CreateDataValueForCalculatedValue( double? calculatedValue, DataValueDto? existingDataValue )
 		{
 			// Copy attributes from existing DataCharacteristic
-			IEnumerable<AttributeDto> valueAttributes = existingDataCharacteristic?.Value?.Attributes ?? Array.Empty<AttributeDto>();
+			IEnumerable<AttributeDto> valueAttributes = existingDataValue?.Attributes ?? Array.Empty<AttributeDto>();
 
 			// Remove measured value because it has been recalculated
 			valueAttributes = valueAttributes.Where( attr => attr.Key != WellKnownKeys.Value.MeasuredValue );
@@ -222,15 +223,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 			if( valueAttributesArray.Length == 0 )
 				return null;
 
-			return new DataCharacteristicDto
-			{
-				Path = PathInformationDto.Combine( characteristic.Path.ParentPath, characteristic.Path.TypedName ),
-				Attributes = characteristic.Attributes,
-				Timestamp = characteristic.Timestamp,
-				Uuid = characteristic.Uuid,
-				Version = characteristic.Version,
-				Value = new DataValueDto( valueAttributesArray )
-			};
+			return new DataValueDto( valueAttributesArray );
 		}
 
 		#endregion
@@ -243,6 +236,6 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics
 		/// <summary>
 		/// Delegate to get a measured value for a characteristic.
 		/// </summary>
-		public delegate double? MeasurementValueHandler( DataMeasurementDto measurement, PathInformationDto path );
+		public delegate double? MeasurementValueHandler( DataMeasurementDto measurement, PathInformationDto characteristicPath );
 	}
 }


### PR DESCRIPTION
Updates project to PiWeb-API 8.0.0 alpha0074. This release turns the `DataValueDto `into a struct and removes `DataCharacteristicDto `since this class did not have any influence to the serialized json string.