### PR TITLE
[PIWEB-21805] feat: "ifnv" also handles NaN and (+/-)infinity as "no value"

### DIFF
--- a/src/CalculatedCharacteristics.Tests/BasicFunctionsTest.cs
+++ b/src/CalculatedCharacteristics.Tests/BasicFunctionsTest.cs
@@ -710,6 +710,9 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests
 		[TestCase( 1.2, null, 1.2 )]
 		[TestCase( null, 3.45, 3.45 )]
 		[TestCase( null, null, null )]
+		[TestCase( double.NaN, 3.45, 3.45 )]
+		[TestCase( double.NegativeInfinity, 3.45, 3.45 )]
+		[TestCase( double.PositiveInfinity, 3.45, 3.45 )]
 		[Test]
 		public void Test_IfNotValue( double? argument1, double? argument2, double? expectedResult )
 		{

--- a/src/CalculatedCharacteristics/Functions/BasicFunctions.cs
+++ b/src/CalculatedCharacteristics/Functions/BasicFunctions.cs
@@ -425,7 +425,12 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 			if( args.Count != 2 )
 				throw new ArgumentException( "Function 'ifnv' requires 2 arguments!" );
 
-			return args.ElementAt( 0 ).GetResult( resolver ) ?? args.ElementAt( 1 ).GetResult( resolver );
+			var result = args.ElementAt( 0 ).GetResult( resolver );
+
+			if( result is null || double.IsNaN( result.Value ) || double.IsInfinity( result.Value ) )
+				return args.ElementAt( 1 ).GetResult( resolver );
+
+			return result;
 		}
 
 		/// <summary>


### PR DESCRIPTION
[PIWEB-21805] The fallback value now is also returned if the first arguments results in NaN or infinity.