### PR TITLE
[PIWEB-23709] fix: PT-PROFILE not depends on tolerances

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,5 +20,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/create-release.yml@main
     with:
       generate_release_notes: true
-      dotnet_version: 8.x
+      dotnet_version: 10.x
     secrets: inherit

--- a/.github/workflows/create-support-release.yml
+++ b/.github/workflows/create-support-release.yml
@@ -18,5 +18,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/create-support-release.yml@main
     with:
       generate_release_notes: true
-      dotnet_version: 8.x
+      dotnet_version: 10.x
     secrets: inherit

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -18,5 +18,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/develop.yml@main
     with:
       do_pack: true  
-      dotnet_version: 8.x
+      dotnet_version: 10.x
     secrets: inherit

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -16,5 +16,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/feature-branch.yml@main
     with:
       do_pack: true 
-      dotnet_version: 8.x
+      dotnet_version: 10.x
     secrets: inherit

--- a/.github/workflows/foss-compliance-scan.yml
+++ b/.github/workflows/foss-compliance-scan.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '8.x' ]
+        dotnet-version: [ '10.x' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/CalculatedCharacteristics.Tests/CalculatedCharacteristics.Tests.csproj
+++ b/src/CalculatedCharacteristics.Tests/CalculatedCharacteristics.Tests.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>Zeiss.PiWeb.CalculatedCharacteristics.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <PackageVersion>5.0.5</PackageVersion>
     <Nullable>enable</Nullable>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly information">

--- a/src/CalculatedCharacteristics.Tests/OprFunctions/PtProfileTest.cs
+++ b/src/CalculatedCharacteristics.Tests/OprFunctions/PtProfileTest.cs
@@ -55,48 +55,6 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests.OprFunctions
 			};
 		}
 
-		private static IEnumerable CreateMissingLowerAndUpperToleranceTestCases()
-		{
-			yield return new OprFunctionTestCase
-			{
-				GivenFormula = "PT_PROFILE({../Mp1};{../Mp3};\"X\")",
-				ExpectedDependentCharacteristics =
-				[
-					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP1", true, "X" ),
-					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP3", true, "X" )
-				],
-				ExpectedResult = null
-			};
-		}
-
-		private static IEnumerable CreateMissingLowerToleranceTestCases()
-		{
-			yield return new OprFunctionTestCase
-			{
-				GivenFormula = "PT_PROFILE({../Mp1};{../Mp4};\"X\")",
-				ExpectedDependentCharacteristics =
-				[
-					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP1", true, "X" ),
-					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP4", true, "X" )
-				],
-				ExpectedResult = null
-			};
-		}
-
-		private static IEnumerable CreateMissingUpperToleranceTestCases()
-		{
-			yield return new OprFunctionTestCase
-			{
-				GivenFormula = "PT_PROFILE({../Mp1};{../Mp4};\"Y\")",
-				ExpectedDependentCharacteristics =
-				[
-					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP1", true, "Y" ),
-					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP4", true, "Y" )
-				],
-				ExpectedResult = null
-			};
-		}
-
 		private static IEnumerable CreateValidDirectionTestCases()
 		{
 			yield return new OprFunctionTestCase
@@ -217,7 +175,19 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests.OprFunctions
 					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP6", false, "Z" ),
 					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP7", false, "Z" )
 				],
-				ExpectedResult = 4.7
+				ExpectedResult = 4.2
+			};
+			yield return new OprFunctionTestCase
+			{
+				GivenFormula = "PT_PROFILE({../Mp2},{../Mp3},{../Mp7};\"X\")",
+				ExpectedDependentCharacteristics =
+				[
+					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP2", true, "X" ),
+					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP3", true, "X" ),
+					new OprFunctionTestCase.ExpectedMeasurementPoint( "MP7", false, "X" )
+				],
+				ExpectedResult = 1,
+				Tolerance = 1e-6
 			};
 		}
 
@@ -230,50 +200,45 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests.OprFunctions
 				new CharacteristicInfo( "N" ),
 				new CharacteristicInfo( "M" )
 			] );
-			var tol = new Tolerance( -1.0, 2.0 );
 			characteristics.AddRange( OprFunctionsTestHelper.CreateMeasurementPoint( "Mp1", [
-				new CharacteristicInfo( "X", null, tol, true ),
-				new CharacteristicInfo( "Y", null, tol ),
-				new CharacteristicInfo( "Z", null, tol ),
-				new CharacteristicInfo( "N", null, tol ),
-				new CharacteristicInfo( "M", null, tol )
+				new CharacteristicInfo( "X", 0.5, isControlItem: true ),
+				new CharacteristicInfo( "Y", 0.5 ),
+				new CharacteristicInfo( "Z", 0.5 ),
+				new CharacteristicInfo( "N", 0.5 ),
+				new CharacteristicInfo( "M", 0.5 )
 			], true ) );
 
-			tol = new Tolerance( -2.0, 2.0 );
 			characteristics.AddRange( OprFunctionsTestHelper.CreateMeasurementPoint( "Mp2", [
-				new CharacteristicInfo( "X", null, tol, true ),
-				new CharacteristicInfo( "Y", null, tol ),
-				new CharacteristicInfo( "Z", null, tol ),
-				new CharacteristicInfo( "N", null, tol ),
-				new CharacteristicInfo( "M", null, tol )
+				new CharacteristicInfo( "X", isControlItem: true ),
+				new CharacteristicInfo( "Y" ),
+				new CharacteristicInfo( "Z" ),
+				new CharacteristicInfo( "N" ),
+				new CharacteristicInfo( "M" )
 			], true ) );
 
 			characteristics.AddRange( OprFunctionsTestHelper.CreateMeasurementPoint( "Mp3", [
 				new CharacteristicInfo( "X" )
 			], true ) );
 
-			var onlyLowerTol = new Tolerance( -2.0, null );
-			var onlyUpperTol = new Tolerance( null, 2.0 );
 			characteristics.AddRange( OprFunctionsTestHelper.CreateMeasurementPoint( "Mp4", [
-				new CharacteristicInfo( "X", null, onlyLowerTol ),
-				new CharacteristicInfo( "Y", null, onlyUpperTol )
+				new CharacteristicInfo( "X" ),
+				new CharacteristicInfo( "Y" )
 			], true ) );
 
-			tol = new Tolerance( -1.0, 3.0 );
 			characteristics.AddRange( OprFunctionsTestHelper.CreateMeasurementPoint( "Mp6", [
-				new CharacteristicInfo( "X", null, tol, true ),
-				new CharacteristicInfo( "Y", null, tol ),
-				new CharacteristicInfo( "Z", null, tol ),
-				new CharacteristicInfo( "N", null, tol ),
-				new CharacteristicInfo( "M", null, tol )
+				new CharacteristicInfo( "X", 1, isControlItem: true ),
+				new CharacteristicInfo( "Y", 1 ),
+				new CharacteristicInfo( "Z", 1 ),
+				new CharacteristicInfo( "N", 1 ),
+				new CharacteristicInfo( "M", 1 )
 			], false ) );
-			tol = new Tolerance( -2.0, 1.0 );
+
 			characteristics.AddRange( OprFunctionsTestHelper.CreateMeasurementPoint( "Mp7", [
-				new CharacteristicInfo( "X", null, tol, true ),
-				new CharacteristicInfo( "Y", null, tol ),
-				new CharacteristicInfo( "Z", null, tol ),
-				new CharacteristicInfo( "N", null, tol ),
-				new CharacteristicInfo( "M", null, tol )
+				new CharacteristicInfo( "X", isControlItem: true ),
+				new CharacteristicInfo( "Y" ),
+				new CharacteristicInfo( "Z" ),
+				new CharacteristicInfo( "N" ),
+				new CharacteristicInfo( "M" )
 			], false ) );
 			return characteristics;
 		}
@@ -406,45 +371,6 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Tests.OprFunctions
 		[Test]
 		[TestCaseSource( nameof( CreateMissingCharacteristicTestCases ) )]
 		public void TestMissingCharacteristic( OprFunctionTestCase testCase )
-		{
-			var characteristics = CreateCharacteristics();
-			var values = CreateMeasurementValues();
-
-			testCase.AssertTestCase( characteristics, values );
-		}
-
-		/// <summary>
-		/// Test multiple characteristics with missing tolerances on Mp3
-		/// </summary>
-		[Test]
-		[TestCaseSource( nameof( CreateMissingLowerAndUpperToleranceTestCases ) )]
-		public void TestMissingLowerAndUpperTolerance( OprFunctionTestCase testCase )
-		{
-			var characteristics = CreateCharacteristics();
-			var values = CreateMeasurementValues();
-
-			testCase.AssertTestCase( characteristics, values );
-		}
-
-		/// <summary>
-		/// Test multiple characteristics with missing lower tolerance on Mp4
-		/// </summary>
-		[Test]
-		[TestCaseSource( nameof( CreateMissingLowerToleranceTestCases ) )]
-		public void TestMissingLowerTolerance( OprFunctionTestCase testCase )
-		{
-			var characteristics = CreateCharacteristics();
-			var values = CreateMeasurementValues();
-
-			testCase.AssertTestCase( characteristics, values );
-		}
-
-		/// <summary>
-		/// Test multiple characteristics with missing upper tolerance on Mp4
-		/// </summary>
-		[Test]
-		[TestCaseSource( nameof( CreateMissingUpperToleranceTestCases ) )]
-		public void TestMissingUpperTolerance( OprFunctionTestCase testCase )
 		{
 			var characteristics = CreateCharacteristics();
 			var values = CreateMeasurementValues();

--- a/src/CalculatedCharacteristics.sln
+++ b/src/CalculatedCharacteristics.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CalculatedCharacteristics", "CalculatedCharacteristics\CalculatedCharacteristics.csproj", "{19B54D6F-EDAE-46B3-8779-6D5DEAE95454}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CalculatedCharacteristics", "CalculatedCharacteristics\CalculatedCharacteristics.csproj", "{19B54D6F-EDAE-46B3-8779-6D5DEAE95454}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CalculatedCharacteristics.Tests", "CalculatedCharacteristics.Tests\CalculatedCharacteristics.Tests.csproj", "{4CB2DBF9-7809-41C7-8563-58BEF7405139}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CalculatedCharacteristics.Tests", "CalculatedCharacteristics.Tests\CalculatedCharacteristics.Tests.csproj", "{4CB2DBF9-7809-41C7-8563-58BEF7405139}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/CalculatedCharacteristics/CalculatedCharacteristics.csproj
+++ b/src/CalculatedCharacteristics/CalculatedCharacteristics.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>Zeiss.PiWeb.CalculatedCharacteristics</RootNamespace>
     <LangVersion>latest</LangVersion>
     <PackageVersion>5.0.5</PackageVersion>
     <Nullable>enable</Nullable>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly information">

--- a/src/CalculatedCharacteristics/Functions/AttributeReader.cs
+++ b/src/CalculatedCharacteristics/Functions/AttributeReader.cs
@@ -1,0 +1,64 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2026                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions;
+
+using System;
+using System.Globalization;
+
+/// <summary>
+/// Delegate for retrieving attribute values.
+/// </summary>
+internal delegate object? AttributeHandler( ushort key );
+
+internal static class AttributeReader
+{
+	/// <summary>
+	/// Retrieves the value of an attribute as a double, if possible.
+	/// The method attempts to convert the attribute value to a double,
+	/// supporting values of type double, string (parsed as a double),
+	/// or other numeric types (converted to double).
+	/// </summary>
+	/// <param name="attributeHandler">A delegate used to retrieve the attribute value by its key.</param>
+	/// <param name="attributeKey">The key of the attribute to retrieve.</param>
+	/// <returns>
+	/// The attribute value as a double, or null if the value is not convertible to a double
+	/// or if the attribute does not exist.
+	/// </returns>
+	public static double? GetDoubleAttributeValue( AttributeHandler attributeHandler, ushort attributeKey )
+	{
+		var value = attributeHandler( attributeKey );
+		if( value == null )
+			return null;
+
+		switch( value )
+		{
+			case double doubleValue:
+				return doubleValue;
+
+			case string stringValue:
+				if( double.TryParse( stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue ) )
+					return parsedValue;
+
+				return null;
+
+			default:
+				try
+				{
+					// Needed to be able to return a double value for a boxed integer value
+					return Convert.ToDouble( value, CultureInfo.InvariantCulture );
+				}
+				catch
+				{
+					return null;
+				}
+		}
+	}
+}

--- a/src/CalculatedCharacteristics/Functions/OprFunctions.cs
+++ b/src/CalculatedCharacteristics/Functions/OprFunctions.cs
@@ -104,7 +104,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		/// * any direction literal (e.g. X,Y,Z,...)
 		/// * [optional] literal "true" to calculate a result only if all characteristics have a value
 		/// </summary>
-		[OperationTemplate( PtMin+"($PATHS;$DIRECTION;$CHECK)", OperationTemplateTypes.PtMin )]
+		[OperationTemplate( PtMin + "($PATHS;$DIRECTION;$CHECK)", OperationTemplateTypes.PtMin )]
 		public static double? Pt_Min( IReadOnlyCollection<MathElement> args, ICharacteristicValueResolver resolver )
 		{
 			var (characteristics, direction) = AnalyzeArguments( args, PtMin, 1, true );
@@ -364,7 +364,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		/// <param name="values2">Measured values for point2 [XYZ]</param>
 		/// <param name="nominalValues2">Nominal values for point2 [XYZ]</param>
 		/// <returns>The calculated distance or <code>null</code> if the distance could not be calculated.</returns>
-		public static double? Calc_Pt_Dist( string direction, double?[] values1, double?[] nominalValues1, double?[] values2, double?[] nominalValues2 )
+		private static double? Calc_Pt_Dist( string direction, double?[] values1, double?[] nominalValues1, double?[] values2, double?[] nominalValues2 )
 		{
 			ValidateForThreePointVector( values1, nameof( values1 ) );
 			ValidateForThreePointVector( values2, nameof( values2 ) );
@@ -485,7 +485,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		[OperationTemplate( PtPosSquare + "($PATH0;$DIRECTION)", OperationTemplateTypes.PtPosSquare )]
 		public static double? Pt_Pos_Square( IReadOnlyCollection<MathElement> args, ICharacteristicValueResolver resolver )
 		{
-			var (characteristics,direction) = AnalyzeArguments( args, PtPosSquare, 1, false, DirectionsAllAxisAndN );
+			var (characteristics, direction) = AnalyzeArguments( args, PtPosSquare, 1, false, DirectionsAllAxisAndN );
 
 			var ch = characteristics[ 0 ];
 
@@ -573,12 +573,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		{
 			var (characteristics, direction) = AnalyzeArguments( args, PtProfile, 1, true );
 
-			var toleratedValues = GetToleratedValues( characteristics, resolver, direction );
-			if( toleratedValues.Length == 0 )
-				return null;
-
-			var values = toleratedValues.Select( v => GetDistanceFromToleranceMiddle( v.Value, v.Tolerance ) ).ToArray();
-			return values.Max() - values.Min();
+			return GetProfileTolerance( characteristics, resolver, direction );
 		}
 
 		/// <summary>
@@ -706,7 +701,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		{
 			var (characteristics, direction) = AnalyzeArguments( args, PtWorstTarget, 1, true, DirectionsXyznp );
 
-			if ( resolver.SourcePath is null)
+			if( resolver.SourcePath is null )
 				throw new ArgumentException( "Function '" + PtWorstTarget + "' requires path of the target characteristic!" );
 
 			if( characteristics.Count == 0 )
@@ -717,12 +712,12 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 				return null;
 
 			IEnumerable<PathInformation?> paths;
-			switch(direction)
+			switch( direction )
 			{
 				case "X":
-					case "Y":
-					case "Z":
-					case "N":
+				case "Y":
+				case "Z":
+				case "N":
 					paths = characteristics.Select( ch => GetDirectionChild( resolver, ch.Path, direction ) );
 					break;
 				case "P":
@@ -837,7 +832,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		/// <param name="valuesP1">Values for the first line point [XYZ]</param>
 		/// <param name="valuesP2">Values for the second line point [XYZ]</param>
 		/// <returns>The calculated distance or <code>null</code> if the distance could not be calculated.</returns>
-		public static double? Calc_Pt_Dist_Pt_2Pt( string direction, double[] valuesP, double[] valuesP1, double[] valuesP2 )
+		private static double? Calc_Pt_Dist_Pt_2Pt( string direction, double[] valuesP, double[] valuesP1, double[] valuesP2 )
 		{
 			ValidateForThreePointVector( valuesP, nameof( valuesP ) );
 			ValidateForThreePointVector( valuesP1, nameof( valuesP1 ) );
@@ -986,7 +981,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 		/// <param name="valuesP2">Values for the second plane point [XYZ]</param>
 		/// <param name="valuesP3">Values for the third plane point [XYZ]</param>
 		/// <returns>The calculated distance or <code>null</code> if the distance could not be calculated.</returns>
-		public static double? Calc_Pt_Dist_Pt_3Pt( string direction, double[] valuesP, double[] valuesP1, double[] valuesP2, double[] valuesP3 )
+		private static double? Calc_Pt_Dist_Pt_3Pt( string direction, double[] valuesP, double[] valuesP1, double[] valuesP2, double[] valuesP3 )
 		{
 			ValidateForThreePointVector( valuesP, nameof( valuesP ) );
 			ValidateForThreePointVector( valuesP1, nameof( valuesP1 ) );
@@ -1115,7 +1110,7 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 
 		private static Tolerance GetTolerance( PathInformation path, ICharacteristicInfoResolver resolver )
 		{
-			var attributeHandler = new ToleranceProvider.AttributeHandler( key => resolver.GetEntityAttributeValue( path, key ) );
+			var attributeHandler = new AttributeHandler( key => resolver.GetEntityAttributeValue( path, key ) );
 			return ToleranceProvider.GetTolerance( attributeHandler );
 		}
 
@@ -1149,6 +1144,40 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 			}
 
 			return valueList.ToArray();
+		}
+
+		private static double? GetProfileTolerance( IEnumerable<Characteristic> characteristics, ICharacteristicValueResolver resolver, string direction )
+		{
+			var paths = characteristics.Select( ch => GetDirectionChild( resolver, ch.Path, direction ) );
+
+			var count = 0;
+			var min = double.MaxValue;
+			var max = double.MinValue;
+			foreach( var path in paths )
+			{
+				if( path == null )
+					return null;
+
+				var value = resolver.GetMeasurementValue( path );
+				if( !value.HasValue )
+					return null;
+
+				count++;
+				var attributeHandler = new AttributeHandler( key => resolver.GetEntityAttributeValue( path, key ) );
+				var targetValue = AttributeReader.GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.DesiredValue );
+				if( targetValue.HasValue )
+					value -= targetValue;
+
+				min = Math.Min( min, value.Value );
+				max = Math.Max( max, value.Value );
+			}
+
+			return count switch
+			{
+				0 => null,
+				1 => 0,
+				_ => max - min
+			};
 		}
 
 		#endregion

--- a/src/CalculatedCharacteristics/Functions/ToleranceProvider.cs
+++ b/src/CalculatedCharacteristics/Functions/ToleranceProvider.cs
@@ -12,8 +12,6 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 {
 	#region usings
 
-	using System;
-	using System.Globalization;
 	using Zeiss.PiWeb.Api.Definitions;
 
 	#endregion
@@ -23,58 +21,19 @@ namespace Zeiss.PiWeb.CalculatedCharacteristics.Functions
 	/// </summary>
 	internal static class ToleranceProvider
 	{
-		#region members
-
-		/// <summary>
-		/// Delegate for retrieving attribute values.
-		/// </summary>
-		public delegate object? AttributeHandler( ushort key );
-
-		#endregion
-
 		#region methods
-
-		private static double? GetDoubleAttributeValue( AttributeHandler attributeHandler, ushort attributeKey )
-		{
-			var value = attributeHandler( attributeKey );
-			if( value == null )
-				return null;
-
-			switch( value )
-			{
-				case double doubleValue:
-					return doubleValue;
-
-				case string stringValue:
-					if( double.TryParse( stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue ) )
-						return parsedValue;
-
-					return null;
-
-				default:
-					try
-					{
-						// Needed to be able to return a double value for a boxed integer value
-						return Convert.ToDouble( value, CultureInfo.InvariantCulture );
-					}
-					catch
-					{
-						return null;
-					}
-			}
-		}
 
 		public static Tolerance GetTolerance( AttributeHandler attributeHandler )
 		{
-			var lower = GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.LowerSpecificationLimit );
-			var upper = GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.UpperSpecificationLimit );
+			var lower = AttributeReader.GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.LowerSpecificationLimit );
+			var upper = AttributeReader.GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.UpperSpecificationLimit );
 
 			if( !lower.HasValue && !upper.HasValue )
 			{
-				var nominal = GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.NominalValue );
+				var nominal = AttributeReader.GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.NominalValue );
 
-				lower = nominal + GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.LowerTolerance );
-				upper = nominal + GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.UpperTolerance );
+				lower = nominal + AttributeReader.GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.LowerTolerance );
+				upper = nominal + AttributeReader.GetDoubleAttributeValue( attributeHandler, WellKnownKeys.Characteristic.UpperTolerance );
 			}
 
 			return new Tolerance( lower, upper );


### PR DESCRIPTION
The original definition states that the distance between the maximum and minimum dimensions should be calculated. The dimension for a point is calculated based on the distance between the measured value and the target/desired value. The author specifies that “0” should always be used for the desired value. However, we have changed this to support the use of the desired value attribute when the profile is shifted.